### PR TITLE
Fixed regex pattern

### DIFF
--- a/i18n/config.py
+++ b/i18n/config.py
@@ -20,7 +20,7 @@ except ImportError:
 
 FILENAME_VARS = dict.fromkeys(
     ("namespace", "locale", "format"),
-    r"\w+",
+    r"(?:\w|-)+",
 )
 
 


### PR DESCRIPTION
\w does not recognize hyphens, causing issues with "en-US" cases. Updated to (?:\w|-)+.