### PR TITLE
Imporved document and use recommended method

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,7 +333,7 @@ i18n.t("days", count=2) # 2 дні
 i18n.t("days", count=5) # 5 днів
 ```
 
-## Devlopment
+## Development
 
 ## Setup Platform
 You can setup the development virtual environment by `python dev-helper.py`.
@@ -343,6 +343,6 @@ You can create git pre-commit hook by `python dev-helper.py install`.
 ## Testing
 You can run tests with `python dev-helper.py run-tests`.
 
-## Checking
-You can run checks with `python dev-helper.py run-checks`.
+## Code Quality Checking
+You can run code quality checks with `python dev-helper.py run-checks`.
 

--- a/README.md
+++ b/README.md
@@ -333,6 +333,16 @@ i18n.t("days", count=2) # 2 дні
 i18n.t("days", count=5) # 5 днів
 ```
 
+## Devlopment
+
+## Setup Platform
+You can setup the development virtual environment by `python dev-helper.py`.
+
+You can create git pre-commit hook by `python dev-helper.py install`.
+
 ## Testing
 You can run tests with `python dev-helper.py run-tests`.
+
+## Checking
+You can run checks with `python dev-helper.py run-checks`.
 

--- a/i18n/config.py
+++ b/i18n/config.py
@@ -1,10 +1,11 @@
 __all__ = ("set", "get")
 
 from typing import Any
-from importlib import reload as _reload, import_module
+from importlib import reload as _reloa
 
 try:
-    import_module("yaml")
+    import yaml
+    
     yaml_available = True
 except ImportError:
     yaml_available = False

--- a/i18n/config.py
+++ b/i18n/config.py
@@ -1,10 +1,10 @@
 __all__ = ("set", "get")
 
 from typing import Any
-from importlib import reload as _reload
+from importlib import reload as _reload, import_module
 
 try:
-    __import__("yaml")
+    import_module("yaml")
     yaml_available = True
 except ImportError:
     yaml_available = False

--- a/i18n/config.py
+++ b/i18n/config.py
@@ -1,7 +1,7 @@
 __all__ = ("set", "get")
 
 from typing import Any
-from importlib import reload as _reloa
+from importlib import reload as _reload
 
 try:
     import yaml


### PR DESCRIPTION
Since python version 3, the document declear that `__import__` is not recommend for highlevel user, and recommend to use `importlib.import_module` instead, so this pull request apply this recommend.

This pr also improve the document for `dev-helper.py`, it's missing in the old version of the i18nice document.